### PR TITLE
ENH: add parsing strategy by InstanceNumber + RepetitionTime

### DIFF
--- a/MultiVolumeImporterPlugin.py
+++ b/MultiVolumeImporterPlugin.py
@@ -28,6 +28,8 @@ class MultiVolumeImporterPluginClass(DICOMPlugin):
     self.tags['position'] = "0020,0032"
     self.tags['studyDescription'] = "0008,1030"
     self.tags['seriesNumber'] = "0020,0011"
+    self.tags['instanceNumber'] = "0020,0013"
+    self.tags['repetitionTime'] = "0018,0080"
 
     # tags used to identify multivolumes
     self.multiVolumeTags = {}
@@ -83,6 +85,9 @@ class MultiVolumeImporterPluginClass(DICOMPlugin):
     # this strategy sorts the files into groups
     loadables += self.examineFilesIPPAcqTime(allfiles)
 
+    # this strategy sorts the files into groups
+    loadables += self.examineFilesIPPInstanceNumber(allfiles)
+
     return loadables
 
 
@@ -125,6 +130,119 @@ class MultiVolumeImporterPluginClass(DICOMPlugin):
       loadables.append(loadable)
 
     return loadables
+
+  def examineFilesIPPInstanceNumber(self,files):
+    """
+    This strategy first orders files into lists, where each list is
+    indexed by ImagePositionPatient (IPP). Next, files within each
+    list are ordered by InstanceNumber attribute. Finally, loadable
+    frames are indexed by InstanceNumber + RepetitionTime, and files within each
+    frame are ordered by IPP.
+    This strategy was required to handle DSC MRI data collected on
+    some GE platforms.
+    """
+
+    loadables = []
+    subseriesLists = {}
+    orderedFiles = []
+
+    desc = slicer.dicomDatabase.fileValue(files[0],self.tags['seriesDescription']) # SeriesDescription
+
+    minTime = int(slicer.dicomDatabase.fileValue(files[0],self.tags['instanceNumber']))
+    for file in files:
+      ipp = slicer.dicomDatabase.fileValue(file,self.tags['position'])
+      time = int(slicer.dicomDatabase.fileValue(file,self.tags['instanceNumber']))
+      if time<minTime:
+        minTime = time
+      if not subseriesLists.has_key(ipp):
+        subseriesLists[ipp] = {}
+      subseriesLists[ipp][time] = file
+
+    nSlicesEqual = True
+    allIPPs = subseriesLists.keys()
+    for ipp in subseriesLists.keys():
+      if len(subseriesLists[allIPPs[0]].keys()) != len(subseriesLists[ipp].keys()):
+        nSlicesEqual = False
+        break
+
+    if len(subseriesLists[allIPPs[0]].keys())<2 or not nSlicesEqual:
+      return []
+
+    if nSlicesEqual:
+      nFrames = len(subseriesLists[allIPPs[0]].keys())
+      nSlices = len(allIPPs)
+
+      orderedFiles = [0] * nFrames * nSlices
+
+      frameLabelsStr=""
+      frameFileListStr = ""
+      frameLabelsArray = vtk.vtkDoubleArray()
+
+      ippPositionCnt = 0
+      for ipp in subseriesLists.keys():
+        timesSorted = subseriesLists[ipp].keys()
+        timesSorted.sort()
+        timeCnt = 0
+        for time in timesSorted:
+          orderedFiles[timeCnt*nSlices+ippPositionCnt] = subseriesLists[ipp][time]
+          timeCnt = timeCnt+1
+          if ippPositionCnt == 0:
+            frameLabelsStr = frameLabelsStr+str(time-minTime)+','
+            frameLabelsArray.InsertNextValue(time-minTime)
+        ippPositionCnt = ippPositionCnt+1
+
+      scalarVolumePlugin = slicer.modules.dicomPlugins['DICOMScalarVolumePlugin']()
+      for f in range(nFrames):
+        frameFileList = orderedFiles[f*nSlices:(f+1)*nSlices]
+        svs = scalarVolumePlugin.examine([frameFileList])
+        if len(svs)==0:
+          print('Failed to parse one of the multivolume frames as scalar volume!')
+          break
+        time = float(slicer.dicomDatabase.fileValue(svs[0].files[0],self.tags['repetitionTime']))*f
+        if f==0:
+            frameLabelsStr = '0,'
+            frameLabelsArray.InsertNextValue(0)
+        else:
+            frameLabelsStr = frameLabelsStr+str(time)+','
+            frameLabelsArray.InsertNextValue(time)
+
+      for file in orderedFiles:
+        frameFileListStr = frameFileListStr+str(file)+','
+
+      frameLabelsStr = frameLabelsStr[:-1]
+      frameFileListStr = frameFileListStr[:-1]
+
+      mvNode = slicer.mrmlScene.CreateNodeByClass('vtkMRMLMultiVolumeNode')
+      mvNode.SetReferenceCount(mvNode.GetReferenceCount()-1)
+      mvNode.SetScene(slicer.mrmlScene)
+      mvNode.SetAttribute("MultiVolume.FrameLabels",frameLabelsStr)
+      mvNode.SetAttribute("MultiVolume.FrameIdentifyingDICOMTagName","Time")
+      mvNode.SetAttribute("MultiVolume.ParseStrategy","TemporalPosition_via_InstanceNumber*RepetitionTime")
+      mvNode.SetAttribute('MultiVolume.NumberOfFrames',str(nFrames))
+      mvNode.SetAttribute('MultiVolume.FrameIdentifyingDICOMTagUnits',"ms")
+      # keep the files in the order by the detected tag
+      # files are not ordered within the individual frames -- this will be
+      # done by ScalarVolumePlugin later
+      mvNode.SetAttribute('MultiVolume.FrameFileList', frameFileListStr)
+
+      self.addAcquisitionAttributes(mvNode, frameFileList)
+
+      mvNode.SetNumberOfFrames(nFrames)
+      mvNode.SetLabelName("Time")
+      mvNode.SetLabelArray(frameLabelsArray)
+
+      loadable = DICOMLib.DICOMLoadable()
+      loadable.files = orderedFiles
+      loadable.name = desc + ' - as a ' + str(nFrames) + ' frames MultiVolume by ImagePositionPatient+InstanceNumber'
+      mvNode.SetName(desc)
+      loadable.tooltip = loadable.name
+      loadable.selected = True
+      loadable.multivolume = mvNode
+      loadable.confidence = 0.9
+      loadables.append(loadable)
+
+    return loadables
+
 
   def examineFilesIPPAcqTime(self,files):
     """


### PR DESCRIPTION
At least some models of GE scanners produce DSC data that does not have any time
stamps that can be associated with the time frames. For such instances, parsing
requires sorting spatially by IPP, and temporally using InstanceNumber, with the
time stamps assigned by multiplying RepetitionTime by the temporal frame position.
This is far from optimal, but there are no alternatives.

Resolves #16