### PR TITLE
ENH: Allow loading of multi-volumes when multiple series are selected in the DICOM browser

### DIFF
--- a/MultiVolumeImporterPlugin.py
+++ b/MultiVolumeImporterPlugin.py
@@ -78,14 +78,15 @@ class MultiVolumeImporterPluginClass(DICOMPlugin):
     allfiles = []
     for files in fileLists:
       loadables += self.examineFiles(files)
+
+      # this strategy sorts the files into groups
+      loadables += self.examineFilesIPPAcqTime(files)
+
       allfiles += files
 
     # here all files are lumped into one list for the situations when
     # individual frames should be parsed from series
     loadables += self.examineFilesMultiseries(allfiles)
-
-    # this strategy sorts the files into groups
-    loadables += self.examineFilesIPPAcqTime(allfiles)
 
     # this strategy sorts the files into groups
     loadables += self.examineFilesIPPInstanceNumber(allfiles)


### PR DESCRIPTION
examineFilesIPPAcqTime fails to recognize 4D Cardiac CT data sets (acquired on Siemens Somatom Definition CT) if multiple series are selected in the DICOM browser.
The problem is that if all selected series are passed to examineFilesIPPAcqTime then the extra series cause varying slice number for each IPP value,
so nSlicesEqual becomes false.

The solution is to pass series to examineFilesIPPAcqTime one-by-one.

Note that I've removed examineFilesIPPAcqTime(allfiles), because most probably examineFilesIPPAcqTime would always fail when it gets multiple series. If you know for sure that there are cases when examineFilesIPPAcqTime has to put together a multi-volume from multiple series then examineFilesIPPAcqTime(allfiles) should note be removed.