### PR TITLE
Fixed local variable 'sec' referenced before assignment error

### DIFF
--- a/MultiVolumeImporterPlugin.py
+++ b/MultiVolumeImporterPlugin.py
@@ -635,8 +635,8 @@ class MultiVolumeImporterPluginClass(DICOMPlugin):
           tag2ValueFileList[frameTag] = tagValue2FileList
 
         tagValueStr = slicer.dicomDatabase.fileValue(file,self.tags[frameTag])
-        if tagValueStr == '':
-          # not found?
+        if tagValueStr == '__TAG_NOT_IN_INSTANCE__' or tagValueStr == '':
+          # not found
           continue
 
         if frameTag == 'AcquisitionTime' or frameTag == 'SeriesTime' or frameTag == 'ContentTime':


### PR DESCRIPTION
When a file cannot be loaded (e.g., removed from disk) then multivolume importer plugin failed with this error:

```
[DEBUG][Qt] 02.10.2017 23:22:13 [] (unknown:0) - Could not load  "C:/Users/msliv/Downloads/dicom4miccai/DICOM4MICCAI-Data/QIN-HEADNECK-01-0024-PET/1.2.276.0.7230010.3.1.4.1334872705.15988.1505074246.702.dcm" 
DCMTK says:  No such file or directory
[DEBUG][Qt] 02.10.2017 23:22:13 [] (unknown:0) - SQL failed
 Bad SQL: INSERT OR REPLACE INTO TagCache VALUES(?,?,?)
[DEBUG][Qt] 02.10.2017 23:22:13 [] (unknown:0) - Error text: attempt to write a readonly database Unable to fetch row
[CRITICAL][Stream] 02.10.2017 23:22:13 [] (unknown:0) - Traceback (most recent call last):
[CRITICAL][Stream] 02.10.2017 23:22:13 [] (unknown:0) -   File "C:\D\S4R\Slicer-build\lib\Slicer-4.7\qt-scripted-modules\DICOMLib\DICOMWidgets.py", line 718, in getLoadablesFromFileLists
[CRITICAL][Stream] 02.10.2017 23:22:13 [] (unknown:0) -     loadablesByPlugin[plugin] = plugin.examine(fileLists)
[CRITICAL][Stream] 02.10.2017 23:22:13 [] (unknown:0) -   File "C:/D/S4R/Slicer-build/lib/Slicer-4.7/qt-scripted-modules/MultiVolumeImporterPlugin.py", line 80, in examine
[CRITICAL][Stream] 02.10.2017 23:22:13 [] (unknown:0) -     loadables += self.examineFiles(files)
[CRITICAL][Stream] 02.10.2017 23:22:13 [] (unknown:0) -   File "C:/D/S4R/Slicer-build/lib/Slicer-4.7/qt-scripted-modules/MultiVolumeImporterPlugin.py", line 430, in examineFiles
[CRITICAL][Stream] 02.10.2017 23:22:13 [] (unknown:0) -     mvNodes = self.initMultiVolumes(subseriesLists[key])
[CRITICAL][Stream] 02.10.2017 23:22:13 [] (unknown:0) -   File "C:/D/S4R/Slicer-build/lib/Slicer-4.7/qt-scripted-modules/MultiVolumeImporterPlugin.py", line 646, in initMultiVolumes
[CRITICAL][Stream] 02.10.2017 23:22:13 [] (unknown:0) -     tagValue = self.tm2ms(tagValueStr) # convert to ms
[CRITICAL][Stream] 02.10.2017 23:22:13 [] (unknown:0) -   File "C:/D/S4R/Slicer-build/lib/Slicer-4.7/qt-scripted-modules/MultiVolumeImporterPlugin.py", line 615, in tm2ms
[CRITICAL][Stream] 02.10.2017 23:22:13 [] (unknown:0) -     sec = sec+ssfrac
[CRITICAL][Stream] 02.10.2017 23:22:13 [] (unknown:0) - UnboundLocalError: local variable 'sec' referenced before assignment
[CRITICAL][Stream] 02.10.2017 23:22:13 [] (unknown:0) - Warning: Plugin failed: MultiVolumeImporterPlugin
[CRITICAL][Stream] 02.10.2017 23:22:13 [] (unknown:0) -
[CRITICAL][Stream] 02.10.2017 23:22:13 [] (unknown:0) - See python console for error message.
[INFO][Stream] 02.10.2017 23:22:23 [] (unknown:0) - DICOM Plugin failed: local variable 'sec' referenced before assignment
```