### PR TITLE
Add support for loading into sequence node and other improvements

### DIFF
--- a/MultiVolumeImporterPlugin.py
+++ b/MultiVolumeImporterPlugin.py
@@ -87,7 +87,9 @@ class MultiVolumeImporterPluginClass(DICOMPlugin):
     # here all files are lumped into one list for the situations when
     # individual frames should be parsed from series
     loadables += self.examineFilesMultiseries(allfiles)
-    loadables += self.examineFilesIPPAcqTime(allfiles)
+    if len(allfiles)>len(files):
+      # only examineFilesIPPAcqTime again if there are multiple file groups
+      loadables += self.examineFilesIPPAcqTime(allfiles)
 
     # this strategy sorts the files into groups
     loadables += self.examineFilesIPPInstanceNumber(allfiles)

--- a/MultiVolumeImporterPlugin.py
+++ b/MultiVolumeImporterPlugin.py
@@ -563,11 +563,15 @@ class MultiVolumeImporterPluginClass(DICOMPlugin):
 
       mvImageArray.T[frameNumber] = frameImageArray
 
-    mvDisplayNode = slicer.mrmlScene.CreateNodeByClass('vtkMRMLMultiVolumeDisplayNode')
-    mvDisplayNode.SetReferenceCount(mvDisplayNode.GetReferenceCount()-1)
-    mvDisplayNode.SetScene(slicer.mrmlScene)
+      # Remove temporary volume node
+      if frame.GetDisplayNode():
+        slicer.mrmlScene.RemoveNode(frame.GetDisplayNode())
+      if frame.GetStorageNode():
+        slicer.mrmlScene.RemoveNode(frame.GetStorageNode())
+      slicer.mrmlScene.RemoveNode(frame)
+
+    mvDisplayNode = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLMultiVolumeDisplayNode')
     mvDisplayNode.SetDefaultColorMap()
-    slicer.mrmlScene.AddNode(mvDisplayNode)
 
     mvNode.SetAndObserveDisplayNodeID(mvDisplayNode.GetID())
     mvNode.SetAndObserveImageData(mvImage)
@@ -714,8 +718,7 @@ class MultiVolumeImporterPluginClass(DICOMPlugin):
       frameLabelsStr = frameLabelsStr[:-1]
 
       mvNode = slicer.mrmlScene.CreateNodeByClass('vtkMRMLMultiVolumeNode')
-      mvNode.SetReferenceCount(mvNode.GetReferenceCount()-1)
-      mvNode.SetScene(slicer.mrmlScene)
+      mvNode.UnRegister(None)
       mvNode.SetAttribute("MultiVolume.FrameLabels",frameLabelsStr)
       mvNode.SetAttribute("MultiVolume.FrameIdentifyingDICOMTagName",frameTag)
       mvNode.SetAttribute('MultiVolume.NumberOfFrames',str(len(tagValue2FileList)))

--- a/MultiVolumeImporterPlugin.py
+++ b/MultiVolumeImporterPlugin.py
@@ -557,7 +557,10 @@ class MultiVolumeImporterPluginClass(DICOMPlugin):
 
     loadAsVolumeSequence = hasattr(loadable, 'loadAsVolumeSequence') and loadable.loadAsVolumeSequence
     if loadAsVolumeSequence:
-      volumeSequenceNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSequenceNode")
+      volumeSequenceNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSequenceNode",
+        slicer.mrmlScene.GenerateUniqueName(mvNode.GetName()))
+      volumeSequenceNode.SetIndexName("")
+      volumeSequenceNode.SetIndexUnit("")
     else:
       mvImage = vtk.vtkImageData()
       mvImageArray = None
@@ -666,6 +669,8 @@ class MultiVolumeImporterPluginClass(DICOMPlugin):
         # faster for images. Images are usually not modified, so the risk of accidentally modifying
         # data in the sequence is low.
         sequenceBrowserNode.SetSaveChanges(volumeSequenceNode, True)
+        # Show frame number in proxy volume node name
+        sequenceBrowserNode.SetOverwriteProxyName(volumeSequenceNode, True);
 
         # Automatically select the volume to display
         imageProxyVolumeNode = sequenceBrowserNode.GetProxyNode(volumeSequenceNode)


### PR DESCRIPTION
Main feature is to allow reading of volume sequences into Sequence nodes. User preference can be defined in Application Settings (by default, it is multi-volume).

Several improvements and fixes have been made to make loading time shorter and give feedback about the progress to the user during loading.
