### PR TITLE
BUG: Fix DICOM settings panel error with Qt5

### DIFF
--- a/MultiVolumeImporterPlugin.py
+++ b/MultiVolumeImporterPlugin.py
@@ -87,7 +87,8 @@ class MultiVolumeImporterPluginClass(DICOMPlugin):
     importFormatsComboBox.currentIndex = 0
     formLayout.addRow("Preferred multi-volume import format:", importFormatsComboBox)
     panel.registerProperty(
-      "DICOM/PreferredMultiVolumeImportFormat", importFormatsComboBox, "currentUserDataAsString", qt.SIGNAL("currentIndexChanged (int)"))
+      "DICOM/PreferredMultiVolumeImportFormat", importFormatsComboBox,
+      "currentUserDataAsString", str(qt.SIGNAL("currentIndexChanged(int)")))
 
   def examine(self,fileLists):
     """ Returns a list of DICOMLoadable instances


### PR DESCRIPTION
This commit fixes the following error:

```
Traceback (most recent call last):
  File "/path/to/Slicer-build/Slicer-build/lib/Slicer-4.9/qt-scripted-modules/DICOM.py", line 90, in performPostModuleDiscoveryTasks
    self.settingsPanel = DICOMSettingsPanel()
  File "/path/to/Slicer-build/Slicer-build/lib/Slicer-4.9/qt-scripted-modules/DICOM.py", line 146, in __init__
    self.ui = _ui_DICOMSettingsPanel(self)
  File "/path/to/Slicer-build/Slicer-build/lib/Slicer-4.9/qt-scripted-modules/DICOM.py", line 139, in __init__
    plugins[pluginName].settingsPanelEntry(parent, pluginGroupBox)
  File "/path/to/Slicer-build/Slicer-build/lib/Slicer-4.9/qt-scripted-modules/MultiVolumeImporterPlugin.py", line 90, in settingsPanelEntry
    "DICOM/PreferredMultiVolumeImportFormat", importFormatsComboBox, "currentUserDataAsString", qt.SIGNAL("currentIndexChanged (int)"))
ValueError: Could not find matching overload for given arguments:
('DICOM/PreferredMultiVolumeImportFormat', ctkComboBox(0x77c7d70) , 'currentUserDataAsString', u'2currentIndexChanged (int)')
```