### PR TITLE
BUG: fix double array allocation

### DIFF
--- a/MultiVolumeImporter.py
+++ b/MultiVolumeImporter.py
@@ -220,9 +220,8 @@ class MultiVolumeImporterWidget(ScriptedLoadableModuleWidget):
     else:
       frameIdMultiplier = 1.0
 
-    volumeLabels.SetNumberOfTuples(nFrames)
     volumeLabels.SetNumberOfComponents(1)
-    volumeLabels.Allocate(nFrames)
+    volumeLabels.SetNumberOfTuples(nFrames)
     for i in range(nFrames):
       frameId = frameIdMultiplier*(self.__veInitial.value+self.__veStep.value*i)
       volumeLabels.SetComponent(i, 0, frameId)
@@ -348,10 +347,8 @@ class MultiVolumeImporterWidget(ScriptedLoadableModuleWidget):
     # create frame labels using the timing info from the file
     # but use the advanced info so user can specify offset and scale
     volumeLabels = vtk.vtkDoubleArray()
-    frameLabelsAttr = ''
     volumeLabels.SetNumberOfTuples(nFrames)
-    volumeLabels.SetNumberOfComponents(1)
-    volumeLabels.Allocate(nFrames)
+    frameLabelsAttr = ''
     for i in range(nFrames):
       frameId = self.__veInitial.value + timeSpacing * self.__veStep.value * i
       volumeLabels.SetComponent(i, 0, frameId)


### PR DESCRIPTION
Calling Allocate on a vtkDoubleArray resets the number of tuples,
leading to the error message below when trying to insert.

This fix uses SetNumberOfTuples, which also does the allocation
to for the correct number of tuples.

Traceback (most recent call last):
  File "/private/tmp/Slicer.app/Contents/lib/Slicer-4.9/qt-scripted-modules/MultiVolumeImporter.py", line 191, in onImportButtonClicked
    self.read4DNIfTI(mvNode, niftiFiles[0])
  File "/private/tmp/Slicer.app/Contents/lib/Slicer-4.9/qt-scripted-modules/MultiVolumeImporter.py", line 357, in read4DNIfTI
    volumeLabels.SetComponent(i, 0, frameId)
ValueError: expects 0 <= tupleIdx && tupleIdx < GetNumberOfTuples()

See:

https://www.vtk.org/doc/nightly/html/classvtkAbstractArray.html#a4d40ec8fbe0eb6c0752ca7890af1ba33