### PR TITLE
Log details when time string parsing fails

### DIFF
--- a/MultiVolumeImporterPlugin.py
+++ b/MultiVolumeImporterPlugin.py
@@ -752,6 +752,8 @@ class MultiVolumeImporterPluginClass(DICOMPlugin):
       sec = float(hhmmss[0:2])*60.*60.+float(hhmmss[2:4])*60.
     elif len(hhmmss)==2: # HH
       sec = float(hhmmss[0:2])*60.*60.
+    else:
+      raise IOError("Invalid DICOM time string: "+tm+" (failed to parse HHMMSS)")
 
     sec = sec+ssfrac
 


### PR DESCRIPTION
In case of DICOM time string conversion fails, this commit throws an exception that contains the time string. This is useful for debugging issues such as https://discourse.slicer.org/t/i-cant-loading-my-ct-image-successfully/4271