### PR TITLE
Fix loading confidence values

### DIFF
--- a/MultiVolumeImporterPlugin.py
+++ b/MultiVolumeImporterPlugin.py
@@ -509,6 +509,10 @@ class MultiVolumeImporterPluginClass(DICOMPlugin):
         loadable.tooltip = loadable.name
         loadable.selected = True
         loadable.multivolume = mvNode
+        if tagName == 'TemporalPositionIdentifier':
+          loadable.confidence = 0.9
+        else:
+          loadable.confidence = 1.
         loadables.append(loadable)
 
     return loadables


### PR DESCRIPTION
Commit https://github.com/fedorov/MultiVolumeImporter/commit/1f7b395566cdfa09aecf68a429afff431657d57c has introduced inconsistent confidence values. This pull request addresses the most important regression, but there are some additional issues to discuss:

1. The most important problem is that the main mechanism for grouping frames (examineFiles) was degraded to confidence = 0.5 !!!
This should have the highest confidence, as it means that a single series is detected as a multi-volume by a known FrameIdentifyingDICOMTag.

In contrast, examineFilesMultiseries is based on a much weaker hypothesis (it lumps together all series in the selection), sets confidence value of 0.9 or 1.0.

2. DICOM plugins in Slicer core should never use confidence value of 1.0 (=absolute certainty) as it prevents more specific plugins in extensions to get highest priority. You choose very high values (0.9, 0.95, 0.99), but never 1.0.

3. Commit comment of https://github.com/fedorov/MultiVolumeImporter/commit/1f7b395566cdfa09aecf68a429afff431657d57c does not match what is done in the commit. Which one is correct? The comment or the code change?

This commit only addresses issue (1).