### PR TITLE
BUG: Add imported multivolume/volumesequence node to subject hierarchy

### DIFF
--- a/MultiVolumeImporterPlugin.py
+++ b/MultiVolumeImporterPlugin.py
@@ -696,6 +696,9 @@ class MultiVolumeImporterPluginClass(DICOMPlugin):
         selNode.SetReferenceActiveVolumeID(imageProxyVolumeNode.GetID())
         appLogic.PropagateVolumeSelection()
 
+        # Show under the right patient/study in subject hierarchy
+        self.addSeriesInSubjectHierarchy(loadable, imageProxyVolumeNode)
+
         # Show sequence browser toolbar
         sequencesModule = slicer.modules.sequences
         if sequencesModule.autoShowToolBar:
@@ -713,6 +716,9 @@ class MultiVolumeImporterPluginClass(DICOMPlugin):
         mvNode.SetNumberOfFrames(nFrames)
         mvNode.SetName(loadable.name)
         slicer.mrmlScene.AddNode(mvNode)
+
+        # Show under the right patient/study in subject hierarchy
+        self.addSeriesInSubjectHierarchy(loadable, mvNode)
 
         #
         # automatically select the volume to display


### PR DESCRIPTION
When a multi-volume or volume sequence was loaded then it was not placed under the patient/study in the subject hierarchy.

@pieper FYI this fixes the issue that Sonia reported last week.