### PR TITLE
ENH: Transfer attributes to Sequence node

### DIFF
--- a/MultiVolumeImporterPlugin.py
+++ b/MultiVolumeImporterPlugin.py
@@ -596,6 +596,9 @@ class MultiVolumeImporterPluginClass(DICOMPlugin):
         slicer.mrmlScene.GenerateUniqueName(baseName))
       volumeSequenceNode.SetIndexName("")
       volumeSequenceNode.SetIndexUnit("")
+      # Transfer all attributes from multivolume node to volume sequence node
+      for attrName in mvNode.GetAttributeNames():
+        volumeSequenceNode.SetAttribute(attrName, mvNode.GetAttribute(attrName))
     else:
       mvImage = vtk.vtkImageData()
       mvImageArray = None


### PR DESCRIPTION
A number of attributes are set on MultiVolume nodes on import, including "MultiVolume.DICOM.EchoTime", "MultiVolume.DICOM.FlipAngle", "MultiVolume.DICOM.RepetitionTime", "MultiVolume.FrameIdentifyingDICOMTagName", and "MultiVolume.FrameLabels".  These were used in modules such as DSCMRIAnalysis.  However, they were not transferred to the volume Sequence node if a Sequence node was imported instead of a MultiVolume node.  Now that the MultiVolume selector widget has been modified to allow selection of Sequence nodes, these attributes need to be transferred in order for things to work the same way as they did for MultiVolumes.  This commit transfers all attributes stored for a MultiVolume node to the corresponding Sequence node on import.