### PR TITLE
PERF: Defer numpy import to first use

### DIFF
--- a/MultiVolumeImporter.py
+++ b/MultiVolumeImporter.py
@@ -3,11 +3,6 @@ import sys, re, os
 from __main__ import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
 
-try:
-  NUMPY_AVAILABLE = True
-  import vtk.util.numpy_support
-except:
-  NUMPY_AVAILABLE = False
 from MultiVolumeImporterLib.Helper import Helper
 
 #
@@ -48,7 +43,8 @@ class MultiVolumeImporterWidget(ScriptedLoadableModuleWidget):
     ScriptedLoadableModuleWidget.setup(self)
     # Instantiate and connect widgets ...
 
-    if not NUMPY_AVAILABLE:
+    import importlib.util
+    if importlib.util.find_spec("numpy") is None:
       label = qt.QLabel('The module is not available due to missing Numpy package.')
       self.layout.addWidget(label)
       label = qt.QLabel('You can seek help by contacting 3D Slicer user list: slicer-users@bwh.harvard.edu')
@@ -148,6 +144,8 @@ class MultiVolumeImporterWidget(ScriptedLoadableModuleWidget):
     l.sort( key=alphanum_key )
 
   def onImportButtonClicked(self):
+    import vtk.util.numpy_support
+
     # check if the output container exists
     mvNode = self.__mvSelector.currentNode()
     if mvNode == None:

--- a/MultiVolumeImporterPlugin.py
+++ b/MultiVolumeImporterPlugin.py
@@ -1,7 +1,6 @@
 import os
 import re
 import vtk, qt, ctk, slicer
-import vtk.util.numpy_support
 import DICOMLib
 from DICOMLib import DICOMPlugin
 from DICOMLib import DICOMLoadable
@@ -585,6 +584,7 @@ class MultiVolumeImporterPluginClass(DICOMPlugin):
     """Load the selection as a MultiVolume, if multivolume attribute is
     present
     """
+    import vtk.util.numpy_support
 
     mvNode = ''
     try:


### PR DESCRIPTION
vtk.util.numpy_support (which imports numpy) was imported at module load in MultiVolumeImporter.py and MultiVolumeImporterPlugin.py. Since these modules are loaded at application startup, this pulled numpy into the startup import path, which is expensive (on Windows, importing numpy can cost a few seconds because the antivirus scans its binaries).

Import vtk.util.numpy_support lazily, in the methods that use it, and check numpy availability in the widget setup with importlib.util.find_spec so no import is needed to decide whether the module can be used.